### PR TITLE
Update leonia webapp image to main-2026-06-01-17-07-17-de6578a

### DIFF
--- a/kubernetes/apps/default/leonia/app/helmrelease.yaml
+++ b/kubernetes/apps/default/leonia/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
           app:
             image:
               repository: ghcr.io/clarknova99/leonia/webapp
-              tag: main-2026-06-01-14-24-39-75cfa98
+              tag: main-2026-06-01-17-07-17-de6578a
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Bumps the leonia HelmRelease image tag to `main-2026-06-01-17-07-17-de6578a` (built from leonia@de6578a50fb0308a70d4c469d4bf939903347708).