### PR TITLE
Update leonia webapp image to main-2026-06-02-02-45-58-2eb8e6e

### DIFF
--- a/kubernetes/apps/default/leonia/app/helmrelease.yaml
+++ b/kubernetes/apps/default/leonia/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
           app:
             image:
               repository: ghcr.io/clarknova99/leonia/webapp
-              tag: main-2026-06-01-17-07-17-de6578a
+              tag: main-2026-06-02-02-45-58-2eb8e6e
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Bumps the leonia HelmRelease image tag to `main-2026-06-02-02-45-58-2eb8e6e` (built from leonia@2eb8e6ec700086a1b6c96629806523e3f3beda2c).