### PR TITLE
Update leonia webapp image to main-2026-06-02-21-23-25-1adac75

### DIFF
--- a/kubernetes/apps/default/leonia/app/helmrelease.yaml
+++ b/kubernetes/apps/default/leonia/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
           app:
             image:
               repository: ghcr.io/clarknova99/leonia/webapp
-              tag: main-2026-06-02-02-45-58-2eb8e6e
+              tag: main-2026-06-02-21-23-25-1adac75
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Bumps the leonia HelmRelease image tag to `main-2026-06-02-21-23-25-1adac75` (built from leonia@1adac759c56c81e8e79933fb3f70c9c908c3cd18).