### PR TITLE
Update leonia webapp image to main-2026-06-02-21-54-59-869ba67

### DIFF
--- a/kubernetes/apps/default/leonia/app/helmrelease.yaml
+++ b/kubernetes/apps/default/leonia/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
           app:
             image:
               repository: ghcr.io/clarknova99/leonia/webapp
-              tag: main-2026-06-02-21-23-25-1adac75
+              tag: main-2026-06-02-21-54-59-869ba67
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Bumps the leonia HelmRelease image tag to `main-2026-06-02-21-54-59-869ba67` (built from leonia@869ba67754204c714a9e766cea1753fb278e61ba).